### PR TITLE
feat: フォームをtsxで記述できるようにする

### DIFF
--- a/core/event/eventManager.ts
+++ b/core/event/eventManager.ts
@@ -1,5 +1,5 @@
-import { world } from "@minecraft/server";
-import { Listener, Priority } from "./types";
+import { world } from '@minecraft/server';
+import { Listener, Priority } from './types';
 
 /**
  * AfterEventMap / BeforeEventMap を world.afterEvents / world.beforeEvents の

--- a/core/form/actionForm.ts
+++ b/core/form/actionForm.ts
@@ -6,7 +6,7 @@ import { ActionFormConfig } from './types';
  * アイコン付きボタンを配置できるアクションフォーム
  */
 export class ActionForm {
-  private readonly config: ActionFormConfig
+  private readonly config: ActionFormConfig;
 
   constructor(config: ActionFormConfig) {
     this.config = config;

--- a/core/form/tsx/components/ActionForm.ts
+++ b/core/form/tsx/components/ActionForm.ts
@@ -1,0 +1,25 @@
+import { ActionButton } from '@/form/types';
+import { ActionForm as ActionFormType, createActionForm } from '@/form/actionForm';
+import { ModalForm } from '@/form/modalForm';
+import { MessageForm } from '@/form/messageForm';
+
+interface ActionFormProps {
+  title: string;
+  body?: string;
+  previousForm?: ModalForm | ActionFormType | MessageForm;
+  children?: ActionButton[];
+};
+
+export default function ActionForm({
+  title,
+  body,
+  previousForm,
+  children = [],
+}: ActionFormProps) {
+  return createActionForm({
+    title,
+    body,
+    previousForm,
+    buttons: children,
+  });
+};

--- a/core/form/tsx/components/Button.ts
+++ b/core/form/tsx/components/Button.ts
@@ -1,0 +1,20 @@
+import { button } from '@/form/components';
+import { Player } from '@minecraft/server';
+
+interface ActionButtonProps {
+  iconPath?: string,
+  children?: string | string[],
+  onClick?: (player: Player) => any,
+};
+
+export default function Button({
+  iconPath = '',
+  children = [],
+  onClick = () => {},
+}: ActionButtonProps) {
+  return button({
+    text: typeof children === 'object' ? children.join('\n') : children,
+    iconPath,
+    handler: onClick,
+  });
+};

--- a/core/form/tsx/components/Dropdown.ts
+++ b/core/form/tsx/components/Dropdown.ts
@@ -1,0 +1,19 @@
+import { dropdown } from '@/form/components';
+
+interface DropdownProps {
+  label: string;
+  options: string[];
+  defaultValueIndex?: number;
+};
+
+export default function Dropdown({
+  label,
+  options,
+  defaultValueIndex,
+}: DropdownProps) {
+  return dropdown({
+    label,
+    options,
+    defaultIndex: defaultValueIndex,
+  });
+};

--- a/core/form/tsx/components/ModalForm.ts
+++ b/core/form/tsx/components/ModalForm.ts
@@ -1,0 +1,26 @@
+import { ActionForm } from '@/form/actionForm';
+import { MessageForm } from '@/form/messageForm';
+import { createModalForm, ModalForm as ModalFormType } from '@/form/modalForm';
+import { FormComponent } from '@/form/types';
+import { Player } from '@minecraft/server';
+
+interface ModalFormProps<T = any> {
+  title: string;
+  previousForm?: ModalFormType | ActionForm | MessageForm;
+  children?: FormComponent[];
+  onSubmit?: (player: Player, values?: T[] | undefined) => any;
+};
+
+export default function ModalForm({
+  title,
+  previousForm,
+  children = [],
+  onSubmit = () => {},
+}: ModalFormProps) {
+  return createModalForm({
+    title,
+    previousForm,
+    components: children,
+    handle: onSubmit,
+  });
+};

--- a/core/form/tsx/components/Slider.ts
+++ b/core/form/tsx/components/Slider.ts
@@ -1,0 +1,25 @@
+import { slider } from '@/form/components';
+
+interface SliderProps {
+  label: string;
+  min: number;
+  max: number;
+  step?: number;
+  defaultValue?: number;
+};
+
+export default function Slider({
+  label,
+  min,
+  max,
+  step,
+  defaultValue = min,
+}: SliderProps) {
+  return slider({
+    label,
+    min,
+    max,
+    step,
+    default: defaultValue,
+  });
+};

--- a/core/form/tsx/components/Textfield.ts
+++ b/core/form/tsx/components/Textfield.ts
@@ -1,0 +1,19 @@
+import { textField } from '@/form/components';
+
+interface TextfieldProps {
+  label: string;
+  placeholder?: string;
+  defaultValue?: string;
+};
+
+export default function Textfield({
+  label,
+  placeholder = '',
+  defaultValue = '',
+}: TextfieldProps) {
+  return textField({
+    label,
+    placeholder,
+    default: defaultValue,
+  });
+};

--- a/core/form/tsx/components/Toggle.ts
+++ b/core/form/tsx/components/Toggle.ts
@@ -1,0 +1,16 @@
+import { toggle } from '@/form/components';
+
+interface ToggleProps {
+  label: string;
+  defaultValue?: boolean;
+};
+
+export default function Toggle({
+  label,
+  defaultValue = false,
+}: ToggleProps) {
+  return toggle({
+    label,
+    default: defaultValue,
+  });
+}

--- a/core/form/tsx/components/index.ts
+++ b/core/form/tsx/components/index.ts
@@ -1,0 +1,17 @@
+import ActionForm from './ActionForm';
+import Button from './Button';
+import ModalForm from './ModalForm';
+import Slider from './Slider';
+import Dropdown from './Dropdown';
+import Textfield from './Textfield';
+import Toggle from './Toggle';
+
+export {
+  ActionForm,
+  Button,
+  ModalForm,
+  Slider,
+  Dropdown,
+  Textfield,
+  Toggle,
+};

--- a/core/form/tsx/runtime.ts
+++ b/core/form/tsx/runtime.ts
@@ -1,0 +1,83 @@
+/**
+ * JSX Fragment 用の一意な識別子
+ */
+export const Fragment = Symbol('Fragment');
+
+/**
+ * JSX で生成される要素の type
+ * - 関数コンポーネント
+ * - Fragment
+ */
+export type JSXElementType =
+  | ((props: any) => any)
+  | typeof Fragment;
+
+/**
+ * JSX のエントリポイント
+ */
+export function createElement(
+  type: JSXElementType,
+  props: any,
+  ...children: any[]
+) {
+  // Fragment は children をそのまま展開
+  if (type === Fragment) {
+    return normalizeChildren(children);
+  }
+
+  if (typeof type !== 'function') {
+    throw new Error('Invalid JSX element type');
+  }
+
+  return type({
+    ...(props ?? {}),
+    children: normalizeChildren(children),
+  });
+}
+
+/**
+ * JSX children を Form DSL 向けに正規化する
+ */
+function normalizeChildren(children: any[]): any[] {
+  return children
+    .flat(Infinity)
+    .filter(
+      (child) =>
+        child !== null &&
+        child !== undefined &&
+        child !== false
+    );
+}
+
+/**
+ * 開発モード用 JSX エントリポイント
+ * デバッグ情報（key, isStaticChildren, source, self）を受け取るが、現在は無視
+ */
+export function jsxDEV(
+  type: JSXElementType,
+  props: any,
+  ..._deps: unknown[]
+) {
+  void _deps;
+  const children = props?.children;
+  const restProps = { ...props };
+  delete restProps.children;
+
+  if (type === Fragment) {
+    return normalizeChildren(Array.isArray(children) ? children : [children]);
+  }
+
+  if (typeof type !== 'function') {
+    throw new Error('Invalid JSX element type');
+  }
+
+  return type({
+    ...restProps,
+    children: normalizeChildren(Array.isArray(children) ? children : [children]),
+  });
+}
+
+export {
+  createElement as jsx,
+  createElement as jsxs,
+};

--- a/core/form/types.ts
+++ b/core/form/types.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { Player } from '@minecraft/server';
 import { ActionFormData, ModalFormData } from '@minecraft/server-ui';
 import { ActionForm } from './actionForm';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,10 @@ import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig({
-  files: ['src/**/*.ts'],
+  files: [
+    'core/**/*.ts',
+    'vite-plugin/**/*.ts',
+  ],
   ignores: ['dev/**/*.ts'],
   extends: [
     eslint.configs.recommended,
@@ -12,5 +15,6 @@ export default defineConfig({
   rules: {
     'quotes': ['error', 'single', { 'allowTemplateLiterals': true }],
     'semi': ['error', 'always'],
+    '@typescript-eslint/no-explicit-any': 'off',
   },
 });

--- a/package.json
+++ b/package.json
@@ -10,11 +10,34 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/core/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "form/jsx-runtime": ["./dist/core/form/tsx/runtime.d.ts"],
+      "form/jsx-dev-runtime": ["./dist/core/form/tsx/runtime.d.ts"],
+      "form/component": ["./dist/core/form/tsx/components/index.d.ts"],
+      "vite-plugin": ["./dist/vite-plugin/index.d.ts"]
+    }
+  },
   "exports": {
     ".": {
       "types": "./dist/core/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./form/jsx-runtime": {
+      "types": "./dist/core/form/tsx/runtime.d.ts",
+      "import": "./dist/form/jsx-runtime/index.js",
+      "default": "./dist/form/jsx-runtime/index.js"
+    },
+    "./form/jsx-dev-runtime": {
+      "types": "./dist/core/form/tsx/runtime.d.ts",
+      "import": "./dist/form/jsx-runtime/index.js",
+      "default": "./dist/form/jsx-runtime/index.js"
+    },
+    "./form/component": {
+      "types": "./dist/core/form/tsx/components/index.d.ts",
+      "import": "./dist/form/component/index.js",
+      "default": "./dist/form/component/index.js"
     },
     "./vite-plugin": {
       "types": "./dist/vite-plugin/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,10 @@
     "listFiles": false,
     "noEmitHelpers": true,
     "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["core/*"]
+    }
   },
   "include": [
     "core/**/*",

--- a/vite-plugin/index.ts
+++ b/vite-plugin/index.ts
@@ -1,5 +1,5 @@
 import type { Plugin, UserConfig } from 'vite';
-import type { OutputBundle, NormalizedOutputOptions, OutputChunk, OutputAsset } from 'rollup';
+import type { OutputBundle, NormalizedOutputOptions } from 'rollup';
 import { resolve } from 'path';
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
@@ -49,14 +49,18 @@ const behaviorPacker = ({
           },
         },
       },
-    }
+      esbuild: {
+        jsx: 'automatic',
+        jsxImportSource: 'keystonemc/form',
+      },
+    };
   },
 
   generateBundle(options: NormalizedOutputOptions, bundle: OutputBundle) {
     if (!embedSourceMap) return;
 
     // バンドル内のチャンクとソースマップを処理
-    for (const [fileName, file] of Object.entries(bundle)) {
+    for (const [, file] of Object.entries(bundle)) {
       if (file.type === 'chunk' && file.map) {
         const sourceMapData = file.map;
         
@@ -106,36 +110,36 @@ globalThis.__SOURCE_MAP__ = ${JSON.stringify(embeddedSourceMap)};
 
     const behaviorUUID = uuid ?? crypto.randomUUID();
     const manifestStub = {
-      "format_version": 2,
-      "header": {
-        "name": name,
-        "description": description,
-        "uuid": behaviorUUID,
-        "version": version,
-        "min_engine_version": [1, 21, 120]
+      'format_version': 2,
+      'header': {
+        'name': name,
+        'description': description,
+        'uuid': behaviorUUID,
+        'version': version,
+        'min_engine_version': [1, 21, 120]
       },
-      "modules": [
+      'modules': [
         {
-          "description": "script",
-          "type": "script",
-          "language": "javascript",
-          "uuid": crypto.randomUUID(),
-          "version": [1, 0, 0],
-          "entry": `scripts/${entryFile.fileName}`,
+          'description': 'script',
+          'type': 'script',
+          'language': 'javascript',
+          'uuid': crypto.randomUUID(),
+          'version': [1, 0, 0],
+          'entry': `scripts/${entryFile.fileName}`,
         }
       ],
-      "dependencies": [
+      'dependencies': [
         {
-          "module_name": "@minecraft/server",
-          "version": "2.4.0"
+          'module_name': '@minecraft/server',
+          'version': '2.4.0'
         },
         {
-          "module_name": "@minecraft/server-ui",
-          "version": "2.0.0"
+          'module_name': '@minecraft/server-ui',
+          'version': '2.0.0'
         },
       ],
-      "metadata": {
-        "authors": authors,
+      'metadata': {
+        'authors': authors,
       }
     };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,11 +4,18 @@ import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [dts()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'core'),
+    },
+  },
   build: {
     ssr: true,
     lib: {
       entry: {
         'index': resolve(__dirname, 'core/index.ts'),
+        'form/jsx-runtime/index': resolve(__dirname, 'core/form/tsx/runtime.ts'),
+        'form/component/index': resolve(__dirname, 'core/form/tsx/components/index.ts'),
         'vite-plugin/index': resolve(__dirname, 'vite-plugin/index.ts'),
       },
       formats: ['es'],


### PR DESCRIPTION
## アクションフォーム
```ts
import { ActionForm as ActionFormType, debug, delayed, EventManager } from 'keystonemc';
import { ActionForm, Button } from 'keystonemc/form/component';


EventManager.registerAfter('playerSpawn', {
  handler(event) {
    if (!event.initialSpawn) return;

    delayed(20 * 5, () => Home().send(event.player));
  },
});

const Home = (): ActionFormType => {
  return <ActionForm
    title="テスト"
  >
    <Button onClick={(player) => debug(player.name)}>
      test
    </Button>
  </ActionForm>;
};
```
![G-jOXhRbQAI9xhS](https://github.com/user-attachments/assets/0ac66e83-54ca-4ba4-942d-b398c67ef1db)

## モーダルフォーム

```tsx
import { Player } from '@minecraft/server';
import { ActionForm as ActionFormType, debug, delayed, EventManager } from 'keystonemc';
import { Dropdown, ModalForm, Slider, Textfield, Toggle } from 'keystonemc/form/component';


EventManager.registerAfter('playerSpawn', {
  handler(event) {
    if (!event.initialSpawn) return;

    delayed(20 * 10, () => Home().send(event.player));
  },
});

const test = (player: Player, values: unknown) => {
  debug(player.name, values);
};

const Home = (): ActionFormType => {
  return <ModalForm
    title="テスト"
    onSubmit={test}
  >
    <Toggle
      label="テストトグル"
      defaultValue={false}
    />
    <Slider
      label="テストスライダー"
      min={0}
      max={10}
      step={1}
      defaultValue={5}
    />
    <Textfield
      label="テストテキストフィールド"
      placeholder="テキスト"
    />
    <Dropdown
      label="テストどろっぴダウン"
      options={['test1', 'test2']}
      defaultValueIndex={0}
    />
  </ModalForm>;
};
```
<img width="680" height="508" alt="image" src="https://github.com/user-attachments/assets/6dc2f9a7-597c-433f-b1e1-d21ad88d43b6" />


---
